### PR TITLE
Add Sadame's birthday

### DIFF
--- a/config/prichan.yml
+++ b/config/prichan.yml
@@ -86,3 +86,7 @@ characters:
   - name:        "ラビリィ"
     birthday:    "3/3"
     description: "うさぎの日"
+
+  # ハイスクールキラッとプリ☆チャン
+  - name:        "銀河さだめ"
+    birthday:    "9/12"


### PR DESCRIPTION
1次ソースは [クラファン特典](https://ubgoe.com/projects/658) の学生証。

自分もクラファン支援しててウラは取れてるんだけど、クラファン支援者以外も見れる情報（例：Xの公式アカウントのポスト）がなく万人が知れる1次ソースとしては弱いのでカレンダーへの登録をずっと躊躇してた。

しかし現在は [ニコニコ大百科](https://dic.nicovideo.jp/a/%E9%8A%80%E6%B2%B3%E3%81%95%E3%81%A0%E3%82%81) や [ピクシブ百科事典](https://dic.pixiv.net/a/%E9%8A%80%E6%B2%B3%E3%81%95%E3%81%A0%E3%82%81) でも掲載されていて2次ソースという意味ではそれなりに公知になってるかなと思い始めたので追加した。
